### PR TITLE
A few minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kaffee's Dual Ride
 
-This is a tiny mod that allows two players to sit on a horse. It uses the Fabric Api and is required on Client and Server. It is licensed under GPLv3. Sourcecode available on [Github](https://github.com/0ql/kaffees_dual_ride).
+This is a tiny mod that allows two players to sit on a horse. It is required on Client and Server. It is licensed under GPLv3. Sourcecode available on [Github](https://github.com/0ql/kaffees_dual_ride).
 
 [Curseforge](https://www.curseforge.com/minecraft/mc-mods/kaffees-dual-ride)
 [Modrinth](https://modrinth.com/mod/kaffees_dual_ride)

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.14.9
 
 # Mod Properties
-	mod_version = 1.0.5
+	mod_version = 1.1.0
 	maven_group = de.tobiasvonmassow
 	archives_base_name = kaffees_dual_ride
 

--- a/src/main/java/de/tobiasvonmassow/kaffees_dual_ride/Kaffees_Dual_Ride.java
+++ b/src/main/java/de/tobiasvonmassow/kaffees_dual_ride/Kaffees_Dual_Ride.java
@@ -1,23 +1,9 @@
 package de.tobiasvonmassow.kaffees_dual_ride;
 
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.passive.AbstractHorseEntity;
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.event.player.UseEntityCallback;
-
-import net.minecraft.util.ActionResult;
 
 public class Kaffees_Dual_Ride implements ModInitializer {
 	@Override
 	public void onInitialize() {
-		UseEntityCallback.EVENT.register((player, world, hand, pos, hitResult) -> {
-			if (!player.isSpectator() && !player.isSneaking()) {
-				final Entity target = hitResult.getEntity();
-				if (target instanceof AbstractHorseEntity && target.getPassengerList().size() < 2) {
-					player.startRiding(target, true);
-				}
-			}
-			return ActionResult.PASS;
-		});
 	}
 }

--- a/src/main/java/de/tobiasvonmassow/kaffees_dual_ride/mixin/DisableSecondRiderFromInterruptingHorseMixin.java
+++ b/src/main/java/de/tobiasvonmassow/kaffees_dual_ride/mixin/DisableSecondRiderFromInterruptingHorseMixin.java
@@ -1,0 +1,31 @@
+package de.tobiasvonmassow.kaffees_dual_ride.mixin;
+
+import net.minecraft.entity.JumpingMount;
+import net.minecraft.entity.passive.AbstractHorseEntity;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(ServerPlayNetworkHandler.class)
+public class DisableSecondRiderFromInterruptingHorseMixin {
+    
+    @Shadow
+    public ServerPlayerEntity player;
+
+    @Redirect(method = "onClientCommand(Lnet/minecraft/network/packet/c2s/play/ClientCommandC2SPacket;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/JumpingMount;startJumping(I)V"))
+    private void startJumping(JumpingMount jm, int i) {
+        if (((AbstractHorseEntity)(Object)jm).getPassengerList().indexOf(this.player) == 0) {
+            jm.startJumping(i);
+        }
+    }
+
+    @Redirect(method = "onClientCommand(Lnet/minecraft/network/packet/c2s/play/ClientCommandC2SPacket;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/JumpingMount;stopJumping()V"))
+    private void stopJumping(JumpingMount jm) {
+        if (((AbstractHorseEntity)(Object)jm).getPassengerList().indexOf(this.player) == 0) {
+            jm.stopJumping();
+        }
+    }
+}

--- a/src/main/java/de/tobiasvonmassow/kaffees_dual_ride/mixin/Kaffees_Dual_Ride_Mixin.java
+++ b/src/main/java/de/tobiasvonmassow/kaffees_dual_ride/mixin/Kaffees_Dual_Ride_Mixin.java
@@ -13,6 +13,8 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 public class Kaffees_Dual_Ride_Mixin {
 	@Inject(at = @At(value = "TAIL"), method = "updatePassengerPosition(Lnet/minecraft/entity/Entity;)V", locals = LocalCapture.CAPTURE_FAILHARD)
 	private void injected(Entity passenger, CallbackInfo ci) {
+		// don't reposition riders if there is only one rider
+		if (((AbstractHorseEntity)(Object)this).getPassengerList().size() < 2) return;
 		// set passengerposition to the position of the horse
 		int i = ((AbstractHorseEntity)(Object)this).getPassengerList().indexOf(passenger);
 		// horizontal offset

--- a/src/main/java/de/tobiasvonmassow/kaffees_dual_ride/mixin/Kaffees_Dual_Ride_Mixin.java
+++ b/src/main/java/de/tobiasvonmassow/kaffees_dual_ride/mixin/Kaffees_Dual_Ride_Mixin.java
@@ -1,16 +1,31 @@
 package de.tobiasvonmassow.kaffees_dual_ride.mixin;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityPose;
+import net.minecraft.entity.EntityType;
 import net.minecraft.entity.passive.AbstractHorseEntity;
+import net.minecraft.entity.passive.AnimalEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
+import com.google.common.collect.ImmutableList;
+
 @Mixin(AbstractHorseEntity.class)
-public class Kaffees_Dual_Ride_Mixin {
+public abstract class Kaffees_Dual_Ride_Mixin extends AnimalEntity {
+
+	protected Kaffees_Dual_Ride_Mixin(EntityType<? extends AbstractHorseEntity> arg, World arg2) {
+		super((EntityType<? extends AnimalEntity>)arg, arg2);
+    }
+
 	@Inject(at = @At(value = "TAIL"), method = "updatePassengerPosition(Lnet/minecraft/entity/Entity;)V", locals = LocalCapture.CAPTURE_FAILHARD)
 	private void injected(Entity passenger, CallbackInfo ci) {
 		// don't reposition riders if there is only one rider
@@ -25,4 +40,25 @@ public class Kaffees_Dual_Ride_Mixin {
 		Vec3d vec3d = new Vec3d(x_offset, 0.0, 0.0).rotateY(-((AbstractHorseEntity)(Object)this).getYaw() * ((float)Math.PI / 180) - 1.5707964f);
 		passenger.setPosition(((AbstractHorseEntity)(Object)this).getX() + vec3d.x,((AbstractHorseEntity)(Object)this).getY() + (double)horizontal_offset,((AbstractHorseEntity)(Object)this).getZ() + vec3d.z);
 	}
+	
+	// abstract class + constructor required so I can extend AnimalEntity to perform this explicit override 
+	@Override
+    public ActionResult interactMob(PlayerEntity player, Hand hand) {
+        if (this.getPassengerList().size() > 0 && this.canAddPassenger(player)) {
+			player.startRiding(this);
+			return ActionResult.success(this.world.isClient);
+        }
+		return super.interactMob(player, hand);
+    }
+
+    @Override
+    protected boolean canAddPassenger(Entity passenger) {
+        return this.getPassengerList().size() < this.getMaxPassengers();
+    }
+
+    protected int getMaxPassengers() {
+        return 2;
+    }
+
+	
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,11 +24,7 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.14.9",
-		"fabric-api": "*",
 		"minecraft": "~1.19",
 		"java": ">=17"
-	},
-	"suggests": {
-		"another-mod": "*"
 	}
 }

--- a/src/main/resources/kaffees_dual_ride.mixins.json
+++ b/src/main/resources/kaffees_dual_ride.mixins.json
@@ -4,9 +4,10 @@
   "package": "de.tobiasvonmassow.kaffees_dual_ride.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "DisableSecondRiderFromInterruptingHorseMixin",
+    "Kaffees_Dual_Ride_Mixin"
   ],
   "client": [
-    "Kaffees_Dual_Ride_Mixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This PR changes the following;
- Passenger offsets are only calculated if there are 2 players on the horse
- Passenger offsets will be performed on both sides
- The second player can't interrupt the horse by jumping anymore
- Fixed the lack of a hand swinging animation when the second player tries to mount the horse
- As a consequence of the previous point, Fabric API is no longer a dependency
